### PR TITLE
Suggestions to generalise beyond QUIC

### DIFF
--- a/draft-kuhn-tsvwg-careful-resume-01.xml
+++ b/draft-kuhn-tsvwg-careful-resume-01.xml
@@ -24,7 +24,7 @@ they will automatically be output with "(if approved)" -->
 full title is longer than 39 characters -->
 
     <title abbrev="Careful congestion control convergence">Careful convergence of congestion 
-    control from retained state with QUIC</title>
+    control from retained state</title>
 
     <author fullname="Nicolas Kuhn" initials="N" surname="Kuhn">
       <organization>Thales Alenia Space</organization>
@@ -99,17 +99,13 @@ keywords will be used for the search engine. -->
 
     <abstract>
       <t>This document discusses careful convergence of 
-      Congestion Control (CC) in QUIC, providing
+      Congestion Control (CC), providing
       a cautious method that enables fast startup in a wide
       range of connections : reconnections using previous transport security credentials (0-RTT context), reconnections between 2 peers (prior knowledge of transport context),
-      application-limited traffic.</t>
+      application-limited traffic. </t>
 
       <!-- start new from v2 to v3 -->
-      <t>The method provides QUIC with transport services that resemble 
-	those     
-	      currently available in TCP, such as TCP Control Block (TCB) <xref target="RFC9040"></xref> caching or
-      updates to support application-limited traffic.</t>
-      <!-- end new from v2 to v3 -->
+	    <t>The method is expected to be appropriate to IETF transports.</t>
 
       <t>The method reuses a set of computed CC parameters that
       are based on the previously observed path characteristics between the
@@ -146,8 +142,12 @@ keywords will be used for the search engine. -->
       	extreme case, persistent congestion could result in unwanted starvation of
       	other flows <xref target="RFC8867"></xref> (i.e., Preventing other flows
 		from successfully sharing a common bottleneck).</t>
+	    
+	<t>When used with the QUIC transport, it provides transport services that resemble 
+	those currently available in TCP, such as TCP Control Block (TCB) <xref target="RFC9040"></xref> caching or
+      updates to support application-limited traffic.</t>
 
-      <t>This document specifies a method that can improve performance by 
+      <t>The specified method can improve performance by 
       reducing the time to get up to speed, and hence can reduce the
       total duration of a transfer.  
       It introduces an alternative method to select initial CC parameters,
@@ -166,10 +166,11 @@ keywords will be used for the search engine. -->
  	in traffic patterns, network routing and link/node failures.
  	There are also cases where using the parameters of a previous
         connection are not appropriate, and a need to evaluate the potential
-        for malicious use of the method.
-	The specification for the QUIC transport protocol <xref
-      	target="RFC9000"></xref> therefore notes "Generally, implementations are advised
-      	to be cautious when using previous values on a new path." </t>
+		for malicious use of the method.</t>
+		
+	<t>"Generally, implementations are advised
+      	to be cautious when using previous values on a new path", as stated in <xref
+      	target="RFC9000"></xref>. This advice is appropriate for any IETF transport protocol.</t>
       	</section>  <!-- end of use with care --> 
           
 	<section title="Receiver Preference">
@@ -203,6 +204,7 @@ keywords will be used for the search engine. -->
 	<section anchor="sec-use_case" title="Examples of Scenarios of Interest">
     
     	        <t> This section provides a set of examples where the method is expected to improve performance.</t>
+		
 	        <t>QUIC introduces the concept of transport parameters (Section 4 of
         	<xref target="RFC9000"></xref>). The present document
 		adds to this by noting that a new
@@ -212,7 +214,7 @@ keywords will be used for the search engine. -->
        		is significantly larger than the IW, and the BDP is also significantly 
 		more than the IW. This benefit is particularly
         	evident for a path where the RTT is much larger than for typical
-        	Internet paths (e.g. SATCOM GEO scenarios).</t>
+        	Internet paths (e.g., SATCOM GEO scenarios).</t>
 		
 		<t>The method can be used by a sender performing a unidirectional data transfer
         	towards the receiver, (e.g., a receiver downloading a file or a web page). This applies to a
@@ -418,8 +420,9 @@ keywords will be used for the search engine. -->
 <section title="Congestion Control Guidelines and Requirements">	
 	
     <t>The sender is limited by any rate-limitation of the transport
-    protocol with which the method is used.
-    For QUIC this includes: flow control mechanisms or amplification
+	    protocol with which the method is used.</t>
+	
+    <t>For QUIC this includes: flow control mechanisms or amplification
     attack prevention. In particular, a QUIC receiver may need to issue proactive
     MAX_DATA frames to increase the flow control limits of a connection
     that is started with this method.</t>

--- a/draft-kuhn-tsvwg-careful-resume-01.xml
+++ b/draft-kuhn-tsvwg-careful-resume-01.xml
@@ -101,8 +101,7 @@ keywords will be used for the search engine. -->
       <t>This document discusses careful convergence of 
       Congestion Control (CC), providing
       a cautious method that enables fast startup in a wide
-      range of connections : reconnections using previous transport security credentials (0-RTT context), reconnections between 2 peers (prior knowledge of transport context),
-      application-limited traffic. </t>
+      range of connections : reconnections using previous transport security credentials, reconnections between a pair of peers (with prior knowledge of the transport context).</t>
 
       <!-- start new from v2 to v3 -->
 	    <t>The method is expected to be appropriate to IETF transports.</t>


### PR DESCRIPTION
We have been asked to generalise beyond QUIC, none-the-less this is something that could alreday be done in TCP, and for which we can make concrete suggestions for QUIC, so let's not do a major disruptive change unless we know what is needed. Instead, I  propose removing the direct dependency on QUIC and a modification to title and abstract to reflect this.